### PR TITLE
:construction: removing the bind address being hardcoded to `127.0.0.1`

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,14 +1,11 @@
-use std::{env, net::SocketAddr};
-
+use std::{env, net::{SocketAddr, IpAddr}};
 use axum::{
     routing::{get, post},
     Router,
 };
 use tower_http::trace::{self, TraceLayer};
 use tracing::Level;
-
 mod detectors;
-
 use detectors::handle_text_contents;
 
 #[tokio::main]
@@ -17,7 +14,8 @@ async fn main() {
         .with_target(false)
         .compact()
         .init();
-
+    
+    // Get port from environment variable or use default
     let mut http_port = 8080;
     if let Ok(port) = env::var("HTTP_PORT") {
         match port.parse::<u16>() {
@@ -26,6 +24,9 @@ async fn main() {
         }
     }
 
+    // Get host from environment variable or use default
+    let host = env::var("HOST").unwrap_or_else(|_| "0.0.0.0".to_string());
+    
     let app = Router::new()
         .route("/health", get(|| async { "Hello, World!" }))
         .route("/api/v1/text/contents", post(handle_text_contents))
@@ -35,9 +36,10 @@ async fn main() {
                 .on_response(trace::DefaultOnResponse::new().level(Level::INFO)),
         );
 
-    let addr = SocketAddr::from(([127, 0, 0, 1], http_port));
+    let ip: IpAddr = host.parse().expect("Failed to parse host IP address");
+    let addr = SocketAddr::from((ip, http_port));
+    
     tracing::info!("listening on {}", addr);
-
     let listener = tokio::net::TcpListener::bind(addr).await.unwrap();
     axum::serve(listener, app).await.unwrap();
 }


### PR DESCRIPTION
Reaching the detectors application via an external route created by Openshift does not appear to be possible as the bind address seems [hardcoded to 127.0.0.1](https://github.com/resoluteCoder/local-detectors/blob/15526d250d4f107c2df9c3ec68e1bd9d28fc421b/src/main.rs#L38), which seems only applicable to localhost.

This PR addresses this problem by listening on 0.0.0.0:8080 by default but should also allow the user to specify the host ip from the environment variable if necessary.

This PR was tested using an image: 'quay.io/rh-ee-mmisiura/local-detectors:pull_request'; accessible [here](https://quay.io/repository/rh-ee-mmisiura/local-detectors?tab=tags)

