### PR TITLE
ci(workflow): run build-and-push in upstream repository only

### DIFF
--- a/.github/workflows/build-and-push-regex-detector.yaml
+++ b/.github/workflows/build-and-push-regex-detector.yaml
@@ -9,7 +9,7 @@ on:
       - "curl.sh"
     tags:
       - v*
-  pull_request_target:
+  pull_request:
     paths-ignore:
       - "README.md"
       - "LICENCE"
@@ -18,6 +18,7 @@ on:
 jobs:
   # Ensure that tests pass before publishing a new image.
   build-and-push-ci:
+    if: github.repository == 'trustyai-explainability/guardrails-regex-detector'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,12 +42,15 @@ jobs:
           mode: minimum
           count: 1
           labels: "ok-to-test, lgtm, approved"
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         if: env.BUILD_CONTEXT == 'ci'
         with:
           ref: ${{ github.event.pull_request.head.sha }}
-      - uses: actions/checkout@v3
+          persist-credentials: false
+      - uses: actions/checkout@v4
         if: env.BUILD_CONTEXT == 'main' ||  env.BUILD_CONTEXT == 'tag'
+        with:
+          persist-credentials: false
       #
       # Print variables for debugging
       - name: Log reference variables


### PR DESCRIPTION
## Summary by Sourcery

Restrict the Docker build-and-push workflow to run only in the upstream repository while aligning it with the latest checkout action.

CI:
- Trigger the workflow on pull_request instead of pull_request_target events and gate execution to the upstream repository.
- Upgrade checkout actions from v3 to v4 and disable credential persistence for all checkout steps.